### PR TITLE
Improve the error message when run without `id-token: write` permission

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -51,6 +51,14 @@ runs:
           echo "$resp"
         }
 
+        if [[ ! -v ACTIONS_ID_TOKEN_REQUEST_TOKEN ]]
+        then
+          message='No $ACTIONS_ID_TOKEN_REQUEST_TOKEN is set. Does this job have the `id-token: write` permission necessary to get a Cloudsmith token?'
+          echo "$message" >&2
+          echo '::error title=Missing `id-token: write` permission?::'"$message"
+          exit 1
+        fi
+
         CLOUDSMITH_ACCOUNT=${CLOUDSMITH_ACCOUNT:-$GITHUB_REPOSITORY_OWNER}
         echo "Retrieving actions OIDC token"
         id_token=$(request -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=api://AzureADTokenExchange" | jq -r '.value')


### PR DESCRIPTION
In some cases an Action may call out to this Action when the job has not been configured with the `permissions: {id-token: write}` setting that [provides the `$ACTIONS_ID_TOKEN_REQUEST_TOKEN` variable](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#adding-permissions-settings). This results in the unclear error:

```text
Retrieving actions OIDC token
/runner/_work/_temp/43750e36-399f-4805-95b5-34d7cabe920f.sh: line 30: ACTIONS_ID_TOKEN_REQUEST_TOKEN: unbound variable
Error: Process completed with exit code 1.
```

Let's check for whether we received the `$ACTIONS_ID_TOKEN_REQUEST_TOKEN` before we try to use it, and if it's missing present a human-readable error developers can use to diagnose their job.

```text
Error: No $ACTIONS_ID_TOKEN_REQUEST_TOKEN is set. Does this job have the `id-token: write` permission necessary to get a Cloudsmith token?
Error: Process completed with exit code 1.
```

![Screenshot 2025-02-04 at 8 50 54 AM](https://github.com/user-attachments/assets/bc51cbe6-2036-4411-9e59-68c99e5f8d6e)

How's this look?